### PR TITLE
chore(format): remove cvss on vulnerability breakdown

### DIFF
--- a/data/vcorp_001.md
+++ b/data/vcorp_001.md
@@ -66,8 +66,6 @@ This vulnerability involves the direct evaluation of untrusted content retrieved
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical command injection vulnerability exists in Acme Corp's deployment script `/usr/local/bin/update_config.sh`. The script retrieves configuration data from an internal server using a non-secured HTTP connection and directly executes the retrieved content using `eval` without any validation or sanitization.
 

--- a/data/vcorp_002.md
+++ b/data/vcorp_002.md
@@ -50,8 +50,6 @@ This vulnerability involves the unsafe practice of piping untrusted remote conte
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's CI/CD pipeline deployment scripts. The scripts fetch remote shell code via an insecure HTTP connection and pipe it directly to bash for execution without any integrity verification. This practice is commonly known as "curl pipe bash" and represents a significant security risk.
 

--- a/data/vcorp_003.md
+++ b/data/vcorp_003.md
@@ -59,8 +59,6 @@ This vulnerability exists in Acme Corp's legacy logging system where the unsafe 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical buffer overflow vulnerability exists in Acme Corp's legacy logging system due to the use of the unsafe `gets()` function in a user input processing module. This C standard library function does not perform any boundary checks, allowing attackers to exceed the fixed-size buffer (64 bytes) and potentially overwrite adjacent memory.
 

--- a/data/vcorp_004.md
+++ b/data/vcorp_004.md
@@ -54,8 +54,6 @@ This vulnerability involves a classic buffer overflow issue caused by using the 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A buffer overflow vulnerability exists in Acme Corp's legacy C-based user management module due to the insecure use of the `scanf()` function without proper bounds checking. The code allocates a fixed-size buffer of 20 bytes for storing a username but fails to limit the input length when reading user data:
 

--- a/data/vcorp_005.md
+++ b/data/vcorp_005.md
@@ -62,8 +62,6 @@ This vulnerability involves improper path handling in Acme Corp's C++ file handl
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability has been identified in Acme Corp's C++ file handling component. The vulnerability exists because the application directly concatenates unsanitized user input to a base directory path without proper validation or canonicalization, potentially allowing attackers to access files outside the intended directory.
 

--- a/data/vcorp_006.md
+++ b/data/vcorp_006.md
@@ -58,8 +58,6 @@ This vulnerability involves a classic format string injection in a C++ microserv
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A format string injection vulnerability exists in Acme Corp's C++ microservice that handles user-supplied log messages via RESTful APIs. The vulnerability occurs in the logging subsystem where user-controlled input is directly passed as the format string parameter to `snprintf()` without proper validation or sanitization.
 

--- a/data/vcorp_007.md
+++ b/data/vcorp_007.md
@@ -82,8 +82,6 @@ This vulnerability involves the direct concatenation of untrusted user input int
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
-
 # Description
 A critical LDAP injection vulnerability exists in Acme Corp's C++ LDAP authentication module. The vulnerability occurs when untrusted user input is directly concatenated into LDAP distinguished names (DN) without proper escaping or sanitization.
 

--- a/data/vcorp_008.md
+++ b/data/vcorp_008.md
@@ -88,8 +88,6 @@ This vulnerability involves improper handling of user input in an LDAP authentic
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 A critical LDAP injection vulnerability has been identified in Acme Corp's C++ authentication module that interfaces with the corporate LDAP directory. The vulnerability stems from user-supplied input being directly concatenated into LDAP filter strings without proper escaping or validation, allowing attackers to manipulate the structure of LDAP queries.
 

--- a/data/vcorp_009.md
+++ b/data/vcorp_009.md
@@ -59,8 +59,6 @@ This vulnerability involves direct string concatenation of untrusted user input 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical SQL injection vulnerability exists in Acme Corp's legacy C++ authentication service that interfaces with a MySQL backend database. The vulnerability occurs when untrusted user input is directly concatenated into SQL query strings without proper sanitization or parameterization.
 

--- a/data/vcorp_010.md
+++ b/data/vcorp_010.md
@@ -58,8 +58,6 @@ This vulnerability involves the direct concatenation of untrusted user input int
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A command injection vulnerability exists in Acme Corp's C++ based logistics application running on Ubuntu 20.04. The vulnerability is located in the file management module, where the application directly concatenates untrusted user input into a command string executed via the standard C library's `system()` function without any validation or sanitization.
 

--- a/data/vcorp_011.md
+++ b/data/vcorp_011.md
@@ -73,8 +73,6 @@ This vulnerability involves a command injection flaw in a .NET Core gRPC service
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A high-severity command injection vulnerability has been identified in Acme Corp's microservices architecture, specifically in a .NET Core-based gRPC service responsible for executing OS commands. The vulnerable service directly incorporates user-supplied input from gRPC requests into shell commands without performing any validation or sanitization. Exploitation requires both VPN access to the internal network and basic authenticated access to the service.
 

--- a/data/vcorp_012.md
+++ b/data/vcorp_012.md
@@ -76,8 +76,6 @@ This vulnerability involves a NoSQL injection flaw in Acme Corp's .NET Core gRPC
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
-
 # Description
 A critical NoSQL injection vulnerability has been identified in Acme Corp's .NET Core gRPC service that interfaces with MongoDB. The vulnerability exists in the `GetUserInfo` method of the `UserService` class, where user-controlled input from a gRPC request is directly concatenated into a MongoDB query without proper sanitization or parameterization.
 

--- a/data/vcorp_013.md
+++ b/data/vcorp_013.md
@@ -61,8 +61,6 @@ This vulnerability involves a classic path traversal issue in Acme Corp's .NET C
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability exists in Acme Corp's microservice named "file-taint-grpc" implemented with .NET Core and gRPC. The vulnerability occurs in the `ReadFile` method which accepts a file name via gRPC call and directly concatenates it to a base directory path without proper validation or sanitization.
 

--- a/data/vcorp_014.md
+++ b/data/vcorp_014.md
@@ -64,8 +64,6 @@ This vulnerability involves a classic SQL injection flaw in Acme Corp's microser
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical SQL injection vulnerability has been discovered in Acme Corp's microservices API, specifically within a gRPC endpoint implemented in C# using .NET Core and Entity Framework. The vulnerability exists because untrusted user input received from gRPC requests is directly concatenated into a raw SQL query without proper sanitization, bypassing the ORM's built-in query parameterization protection.
 

--- a/data/vcorp_015.md
+++ b/data/vcorp_015.md
@@ -65,8 +65,6 @@ This vulnerability involves a classic Server-Side Request Forgery (SSRF) pattern
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
-
 # Description
 A Server-Side Request Forgery (SSRF) vulnerability exists in Acme Corp's .NET Core microservice architecture that uses gRPC for communication. The vulnerability is located in the HTTP client integration where unvalidated user input is directly incorporated into the base URL for outgoing HTTP requests.
 

--- a/data/vcorp_016.md
+++ b/data/vcorp_016.md
@@ -77,8 +77,6 @@ This vulnerability involves the unsafe construction of XPath queries by directly
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 An XPath injection vulnerability exists in Acme Corp's .NET Core gRPC service, specifically in the `UserDataService.GetUserDetails` method. The vulnerability occurs because the application constructs XPath queries by directly concatenating untrusted user input (`request.UserId`) into the query string without proper validation or sanitization.
 

--- a/data/vcorp_017.md
+++ b/data/vcorp_017.md
@@ -73,8 +73,6 @@ This vulnerability involves a classic XML External Entity (XXE) injection flaw i
    - Integrity (I): Low (L) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
-
 # Description
 An XML External Entity (XXE) vulnerability exists in Acme Corp's ASP.NET Core application due to improper configuration of the built-in XML parser. The application's XML processing module accepts user-provided XML through an API endpoint but fails to disable Document Type Definition (DTD) processing, creating a significant security risk.
 

--- a/data/vcorp_018.md
+++ b/data/vcorp_018.md
@@ -55,8 +55,6 @@ This vulnerability in Acme Corp's ASP.NET MVC application enables cross-site req
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N
-
 # Description
 A significant security vulnerability has been identified in Acme Corp's ASP.NET MVC application, specifically in the `UpdateAccountSettings` method of the `AccountController`. The controller method lacks two critical security controls: antiforgery token validation and strict content-type checking.
 

--- a/data/vcorp_019.md
+++ b/data/vcorp_019.md
@@ -71,8 +71,6 @@ This vulnerability involves insecure deserialization of untrusted data in a lega
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical vulnerability exists in Acme Corp's legacy .NET application where a public API endpoint deserializes data using the insecure `BinaryFormatter` class without proper validation. This Windows service, which processes incoming binary data streams running on .NET Framework 4.7 in an Azure environment, fails to validate the types being deserialized, allowing attackers to supply crafted payloads leading to remote code execution.
 

--- a/data/vcorp_020.md
+++ b/data/vcorp_020.md
@@ -68,8 +68,6 @@ This vulnerability involves a critical configuration issue in the ASP.NET Core A
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical insecure deserialization vulnerability has been identified in Acme Corp's ASP.NET Core API which uses Newtonsoft.Json with the dangerous `TypeNameHandling.All` configuration without implementing a custom `SerializationBinder`. This misconfiguration allows attackers to supply JSON payloads containing arbitrary type specifications that can lead to instantiation of dangerous types during deserialization.
 

--- a/data/vcorp_021.md
+++ b/data/vcorp_021.md
@@ -77,8 +77,6 @@ This vulnerability involves the improper configuration of error handling in an A
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-
 # Description
 A security vulnerability was identified in Acme Corp's ASP.NET Core web API running in production, where detailed stack trace information is inappropriately disclosed to end users when errors occur. This misconfiguration exposes sensitive internal details including file paths, method names, line numbers, and potentially database structure, significantly assisting attackers in reconnaissance and targeted exploitation efforts.
 

--- a/data/vcorp_022.md
+++ b/data/vcorp_022.md
@@ -49,8 +49,6 @@ This vulnerability analysis examines a critical container security weakness invo
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's Docker container infrastructure where the host's Docker socket (`/var/run/docker.sock`) is directly mounted into containers. This dangerous configuration effectively grants container processes complete access to the host's Docker daemon, breaking the fundamental isolation guarantee of containerization.
 

--- a/data/vcorp_023.md
+++ b/data/vcorp_023.md
@@ -51,8 +51,6 @@ This vulnerability stems from a critical security misconfiguration in Acme Corp'
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A security vulnerability has been identified in Acme Corp's containerized microservices, specifically in a critical Docker image used for a Node.js web server. The Dockerfile omits the `USER` directive, resulting in all container processes running with root privileges. This misconfiguration violates the principle of least privilege and creates significant security risks.
 

--- a/data/vcorp_024.md
+++ b/data/vcorp_024.md
@@ -47,8 +47,6 @@ This vulnerability involves a path traversal issue in Acme Corp's NGINX server c
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-
 # Description
 A path traversal vulnerability exists in Acme Corp's public-facing NGINX server (running on Ubuntu 20.04 LTS with a PHP-FPM backend) due to a misconfiguration in the static file handling. The `alias` directive in the `location` block is defined without a trailing slash, which inadvertently enables directory traversal attacks:
 

--- a/data/vcorp_025.md
+++ b/data/vcorp_025.md
@@ -59,8 +59,6 @@ This vulnerability involves the improper handling of unsanitized user input in N
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
-
 # Description
 A header injection vulnerability exists in Acme Corp's NGINX configuration that handles dynamic URL path parameters. The implementation directly injects unsanitized variables captured from the path into HTTP response headers, without checking for whitespace or newline characters.
 

--- a/data/vcorp_026.md
+++ b/data/vcorp_026.md
@@ -51,8 +51,6 @@ This vulnerability involves an improper Nginx configuration that fails to enforc
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N
-
 # Description
 An insecure redirect vulnerability exists in Acme Corp's Nginx configuration (version 1.18) running in Docker containers on AWS EC2. The configuration fails to specify the HTTPS scheme when redirecting users from the `/old-ui` path, causing the web server to maintain the original protocol used by the client.
 

--- a/data/vcorp_027.md
+++ b/data/vcorp_027.md
@@ -49,8 +49,6 @@ This vulnerability involves Nginx reverse proxies improperly handling HTTP proto
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
-
 # Description
 A security vulnerability was identified in Acme Corp's externally exposed Nginx reverse proxies where improper handling of HTTP/1.1 Upgrade headers enables H2C (HTTP/2 Cleartext) smuggling attacks. The misconfiguration allows HTTP/1.1 requests containing `Upgrade: h2c` headers to be forwarded to backend servers instead of strictly validating that only `Upgrade: websocket` headers are permitted.
 

--- a/data/vcorp_028.md
+++ b/data/vcorp_028.md
@@ -62,8 +62,6 @@ This vulnerability involves directly embedding AWS credentials (Access Key ID an
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical security vulnerability exists in Acme Corp's internal microservices repository where AWS credentials (both Access Key ID and Secret Access Key) are hardcoded directly in a Python source file. The code uses these embedded credentials to authenticate with AWS S3 services via the Boto3 SDK.
 

--- a/data/vcorp_029.md
+++ b/data/vcorp_029.md
@@ -62,8 +62,6 @@ This vulnerability involves hardcoded AWS credentials (Access Key ID and Secret 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's codebase, where AWS credentials (Access Key ID and Secret Access Key) were hardcoded directly in a Python configuration file and committed to a public Git repository. The exposure was discovered during a routine secrets scanning operation targeting public repositories.
 

--- a/data/vcorp_030.md
+++ b/data/vcorp_030.md
@@ -65,8 +65,6 @@ This vulnerability involves embedding a static, generic API key directly in the 
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 A critical security vulnerability was discovered in Acme Corp's Node.js backend application where a generic API key (`GENERIC_API_KEY_12345`) is hard-coded directly into the production source code. This API key, originally intended for integration testing, was inadvertently deployed to the production environment and subsequently exposed through public version control history.
 

--- a/data/vcorp_031.md
+++ b/data/vcorp_031.md
@@ -52,8 +52,6 @@ This vulnerability involves hardcoded database credentials detected in a Node.js
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's Node.js application where database credentials are hardcoded directly in a legacy configuration file. During a routine audit, automated secrets scanning detected a high-entropy string pattern in a source code repository, specifically a plaintext database password stored in `config.js`.
 

--- a/data/vcorp_032.md
+++ b/data/vcorp_032.md
@@ -64,8 +64,6 @@ This vulnerability involves the exposure of a JWT (JSON Web Token) secret direct
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A hard-coded JWT secret was discovered in Acme Corp's Node.js/Express web application's configuration file. This secret was inadvertently committed to the production repository despite being initially intended for internal testing purposes. The secret is used to sign JSON Web Tokens for user authentication and session management.
 

--- a/data/vcorp_033.md
+++ b/data/vcorp_033.md
@@ -64,8 +64,6 @@ This vulnerability involves an RSA private key for JWT authentication being hard
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's Node.js web application during static code analysis. An RSA private key used for JWT (JSON Web Token) authentication has been hardcoded directly in a configuration file (`config.js`) and committed to the production Git repository.
 

--- a/data/vcorp_034.md
+++ b/data/vcorp_034.md
@@ -92,8 +92,6 @@ This vulnerability exists in Acme Corp's AWS Lambda function written in Go which
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
-
 # Description
 A critical SQL injection vulnerability has been discovered in an Acme Corp AWS Lambda function written in Go. The function accepts user input from the event object and directly concatenates this input into a SQL query without proper sanitization or parameterization.
 

--- a/data/vcorp_035.md
+++ b/data/vcorp_035.md
@@ -72,8 +72,6 @@ This vulnerability involves direct execution of unsanitized user input via shell
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A command injection vulnerability has been discovered in Acme Corp's Go web application built with the Gin framework. The application contains an endpoint at `/execute` that directly passes user-supplied query parameters to the system shell without any validation or sanitization. This endpoint is only accessible from the internal network via VPN and requires administrative credentials due to authentication middleware.
 

--- a/data/vcorp_036.md
+++ b/data/vcorp_036.md
@@ -76,9 +76,6 @@ This vulnerability involves direct injection of untrusted user input into MongoD
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
 
 # Description
 A high-severity NoSQL Injection vulnerability exists in Acme Corp's user management API built with the Go Gin framework and MongoDB. The vulnerability occurs in the `/user` endpoint where user-supplied query parameters are directly incorporated into MongoDB query filters without proper validation or sanitization.

--- a/data/vcorp_037.md
+++ b/data/vcorp_037.md
@@ -71,8 +71,6 @@ This vulnerability involves a path traversal weakness in Acme Corp's Go-based mi
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability has been identified in Acme Corp's Go-based microservice API built using the Gin framework. The vulnerable endpoint (`/file`) accepts a filename via a query parameter and uses it to construct a file path without proper validation. Although the code attempts to sanitize the input using `filepath.Clean()`, this function only normalizes paths and does not prevent directory traversal attacks.
 

--- a/data/vcorp_038.md
+++ b/data/vcorp_038.md
@@ -84,8 +84,6 @@ This vulnerability involves a server-side request forgery (SSRF) issue in Acme C
    - Integrity (I): Low (L) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:L
-
 # Description
 A critical Server-Side Request Forgery (SSRF) vulnerability exists in Acme Corp's Go-based Gin web application that could allow attackers to send unauthorized HTTP requests to internal networks or external systems. The vulnerable endpoint `/fetch` directly concatenates an untrusted `host` parameter with a hardcoded HTTP scheme and `/admin` path without any validation or sanitization.
 

--- a/data/vcorp_039.md
+++ b/data/vcorp_039.md
@@ -79,8 +79,6 @@ This vulnerability involves a persistent cross-site scripting (XSS) issue in Acm
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N
-
 # Description
 A Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's web application built with Go and the Gin framework. The vulnerability is present in the `/welcome` endpoint, which accepts a `username` parameter via query string and renders it directly in a web page template.
 

--- a/data/vcorp_040.md
+++ b/data/vcorp_040.md
@@ -71,8 +71,6 @@ This vulnerability represents a severe OS command injection flaw in a Go microse
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical command injection vulnerability has been discovered in Acme Corp's Go-based microservices utilizing the Gorilla Mux framework. The application exposes an HTTP endpoint (`/run`) that accepts a query parameter (`cmd`) and directly passes this user-controlled input to the operating system for execution via Go's `exec.Command` function with a bash shell interpreter.
 

--- a/data/vcorp_041.md
+++ b/data/vcorp_041.md
@@ -95,8 +95,6 @@ This vulnerability involves a critical NoSQL injection weakness in Acme Corp's G
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A severe NoSQL injection vulnerability exists in Acme Corp's Go-based web service that uses the Gorilla Mux framework with MongoDB. The vulnerability is located in the user query functionality where untrusted user input from URL parameters is directly embedded into a MongoDB query's `$where` clause without any sanitization.
 

--- a/data/vcorp_042.md
+++ b/data/vcorp_042.md
@@ -74,8 +74,6 @@ This vulnerability involves a path traversal issue in Acme Corp's Golang web app
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability exists in Acme Corp's Golang web application using the Gorilla Mux router. The vulnerability is present in the `/files/{filename}` API endpoint, which constructs file paths by directly concatenating unsanitized user input to a base directory path without proper validation.
 

--- a/data/vcorp_043.md
+++ b/data/vcorp_043.md
@@ -69,8 +69,6 @@ This vulnerability involves the absence of the HttpOnly flag in session cookies 
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N
-
 # Description
 A security vulnerability was discovered in Acme Corp's Golang web application that uses the Gorilla sessions library for session management. The application is configured to issue session cookies without the `HttpOnly` flag, which is a critical security attribute that prevents client-side scripts from accessing cookie data.
 

--- a/data/vcorp_044.md
+++ b/data/vcorp_044.md
@@ -85,8 +85,6 @@ This vulnerability involves improper handling of user input in a Go web applicat
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:L
-
 # Description
 A SQL injection vulnerability exists in Acme Corp's Go-based web application, specifically in the admin-only user search API endpoint. The vulnerability stems from insecure coding practices where user input from URL query parameters is directly concatenated into SQL queries without proper sanitization or parameterization.
 

--- a/data/vcorp_045.md
+++ b/data/vcorp_045.md
@@ -82,8 +82,6 @@ This vulnerability involves an SSRF issue in Acme Corp's Golang microservice tha
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
-
 # Description
 A critical Server-Side Request Forgery (SSRF) vulnerability has been identified in Acme Corp's Golang microservice built with the Gorilla toolkit. The vulnerability exists in the `/proxy` endpoint, which accepts a user-supplied `host` parameter that is directly concatenated into a URL string without validation or sanitization.
 

--- a/data/vcorp_046.md
+++ b/data/vcorp_046.md
@@ -65,8 +65,6 @@ This vulnerability involves an unsanitized direct output of user-controlled data
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
-
 # Description
 A Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's Go-based web application using the Gorilla mux router. The vulnerability occurs in the `/vulnerable` endpoint handler where user input from query parameters is retrieved and directly inserted into HTML output without any sanitization or encoding.
 

--- a/data/vcorp_047.md
+++ b/data/vcorp_047.md
@@ -69,8 +69,6 @@ This vulnerability allows remote attackers to execute arbitrary operating system
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A command injection vulnerability exists in Acme Corp's Go-based gRPC microservices that allows attackers to execute arbitrary shell commands on the underlying operating system. The vulnerability stems from improper handling of user input in an administrative gRPC endpoint where the application directly passes client-provided command strings to the operating system shell via `exec.Command("bash", "-c", userInput)` without any sanitization or validation.
 

--- a/data/vcorp_048.md
+++ b/data/vcorp_048.md
@@ -63,8 +63,6 @@ This vulnerability involves using unencrypted gRPC communication in Acme Corp's 
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A security vulnerability has been identified in Acme Corp's Go-based microservices infrastructure where gRPC client connections are established without TLS encryption by using the `grpc.WithInsecure()` option. This insecure configuration was discovered during static code review of inter-service communication components.
 

--- a/data/vcorp_049.md
+++ b/data/vcorp_049.md
@@ -90,8 +90,6 @@ This vulnerability involves a classic SQL injection pattern in a Go-based gRPC m
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A SQL injection vulnerability has been identified in Acme Corp's gRPC microservice. The vulnerability exists in the `GetUser` function where user-supplied input from gRPC requests (`req.Username`) is directly interpolated into a SQL query using `fmt.Sprintf()` without any sanitization or validation.
 

--- a/data/vcorp_050.md
+++ b/data/vcorp_050.md
@@ -100,8 +100,6 @@ This vulnerability involves a Go-based gRPC service that constructs outbound HTT
    - Integrity (I): None (N) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:L
-
 # Description
 A critical Server-Side Request Forgery (SSRF) vulnerability has been identified in Acme Corp's Go-based gRPC service. The vulnerability exists in the `HandleRequest` function where a user-supplied parameter (`TargetHost`) is directly embedded into a URL string without any validation or sanitization.
 

--- a/data/vcorp_051.md
+++ b/data/vcorp_051.md
@@ -66,8 +66,6 @@ This vulnerability involves a critical authentication bypass in Acme Corp's Go-b
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A critical authentication bypass vulnerability exists in Acme Corp's Go-based API services due to improper JWT validation. The application uses the `jwt-go` library but fails to verify the signing algorithm, allowing attackers to forge tokens with the `none` algorithm that bypass signature verification entirely.
 

--- a/data/vcorp_052.md
+++ b/data/vcorp_052.md
@@ -66,8 +66,6 @@ This vulnerability involves the use of a non-cryptographic pseudo-random number 
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A critical vulnerability has been identified in Acme Corp's Golang-based microservices architecture, specifically in the session token generation functionality. The authentication service is using the standard library's `math/rand` package, which is a non-cryptographically secure pseudo-random number generator (PRNG), to generate security-critical session tokens.
 

--- a/data/vcorp_053.md
+++ b/data/vcorp_053.md
@@ -64,8 +64,6 @@ This vulnerability involves the continued use of the deprecated and insecure SSL
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 A critical cryptographic vulnerability has been identified in Acme Corp's Golang-based microservices, where an API endpoint responsible for secure communications is configured to accept the deprecated SSLv3 protocol. The code explicitly sets `tls.VersionSSL30` as the minimum allowed TLS version, despite SSLv3 being known to be vulnerable to several attacks, most notably POODLE.
 

--- a/data/vcorp_054.md
+++ b/data/vcorp_054.md
@@ -71,8 +71,6 @@ This vulnerability involves the explicit configuration of deprecated and weak TL
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 A security vulnerability has been identified in Acme Corp's microservices infrastructure where Go applications (version 1.16) have been explicitly configured to use deprecated and insecure TLS cipher suites, most notably `tls.TLS_RSA_WITH_RC4_128_SHA`. Additionally, the TLS minimum version has been set to 1.0, which is considered obsolete by modern security standards.
 

--- a/data/vcorp_055.md
+++ b/data/vcorp_055.md
@@ -62,8 +62,6 @@ This vulnerability involves the generation of RSA keys with insufficient key len
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A cryptographic vulnerability has been identified in Acme Corp's Go-based microservices where RSA keys are being generated with insufficient bit length (1024 bits), falling below the industry-recommended minimum of 2048 bits. The vulnerable code uses the Go `crypto/rsa` package with a legacy configuration that doesn't enforce adequate key length validation.
 

--- a/data/vcorp_056.md
+++ b/data/vcorp_056.md
@@ -67,8 +67,6 @@ This vulnerability involves the absence of the HttpOnly flag on session cookies 
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A security vulnerability has been identified in Acme Corp's Go-based web application where session cookies issued by the authentication service are missing the `HttpOnly` flag. This was discovered during a code review, which found that the flag was specifically commented out in the cookie creation code.
 

--- a/data/vcorp_057.md
+++ b/data/vcorp_057.md
@@ -68,8 +68,6 @@ This vulnerability involves a security misconfiguration in Acme Corp's Go-based 
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
-
 # Description
 A security vulnerability has been identified in Acme Corp's Go-based web application, specifically in the session cookie configuration of the authentication module. The application sets session cookies without the `Secure` flag, allowing these cookies to be transmitted over unencrypted HTTP connections.
 

--- a/data/vcorp_058.md
+++ b/data/vcorp_058.md
@@ -83,8 +83,6 @@ This vulnerability involves a Cross-Site Scripting (XSS) flaw in a Golang web ap
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's Golang web application, specifically in the search functionality. The vulnerability stems from the improper use of Go's `template.URL()` function, which marks a string as a trusted URL that should not undergo HTML escaping.
 

--- a/data/vcorp_059.md
+++ b/data/vcorp_059.md
@@ -62,8 +62,6 @@ This vulnerability involves direct inclusion of user-supplied input into HTML ou
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's Go-based web service, specifically in the HTTP handler function that processes user greetings. The vulnerable code directly concatenates unsanitized user input from URL query parameters into HTML output without proper escaping, bypassing the security protections provided by Go's `html/template` package.
 

--- a/data/vcorp_060.md
+++ b/data/vcorp_060.md
@@ -85,8 +85,6 @@ This vulnerability involves an unbounded decompression mechanism in Acme Corp's 
    - Integrity (I): None (N) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
-
 # Description
 A medium-severity vulnerability has been identified in Acme Corp's Go-based file upload microservice. The service improperly handles decompression of ZIP files by using an unbounded `io.Copy()` function without implementing size limits, making it susceptible to decompression bomb attacks.
 

--- a/data/vcorp_061.md
+++ b/data/vcorp_061.md
@@ -61,8 +61,6 @@ This vulnerability involves incorrect usage of Go's `filepath.Clean` function wh
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability exists in Acme Corp's Golang-based file server due to improper sanitization of file paths from HTTP requests. The application incorrectly relies on `filepath.Clean` to secure file paths, but this function only normalizes paths without preventing directory traversal attacks.
 

--- a/data/vcorp_062.md
+++ b/data/vcorp_062.md
@@ -59,8 +59,6 @@ This vulnerability involves an open redirect flaw in Acme Corp's Go-based web ap
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N
-
 # Description
 An open redirect vulnerability has been identified in Acme Corp's Go-based web application. The vulnerability exists in the `/redirect` endpoint, which constructs HTTP redirects based on unsanitized user input from the query parameter `request`. The application directly uses this parameter in the `http.Redirect()` function without any validation or allowlisting of permitted destinations.
 

--- a/data/vcorp_063.md
+++ b/data/vcorp_063.md
@@ -86,8 +86,6 @@ This vulnerability involves a Go-based microservice that accepts user input to c
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N
-
 # Description
 A critical Server-Side Request Forgery (SSRF) vulnerability was discovered in Acme Corp's Go-based microservice deployed on Kubernetes. The vulnerability exists in the `/fetch` endpoint, which accepts a user-supplied `url_host` parameter and directly incorporates it into constructing a URL for an outbound HTTP request without any validation.
 

--- a/data/vcorp_064.md
+++ b/data/vcorp_064.md
@@ -74,8 +74,6 @@ This vulnerability involves a lack of CSRF protection in a Go web application us
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N
-
 # Description
 A Cross-Site Request Forgery (CSRF) vulnerability exists in Acme Corp's Go-based web application due to the absence of CSRF protection mechanisms in HTTP endpoints implemented with the standard `net/http` package. The application relies on cookie-based session management but fails to implement CSRF token validation, notably missing the Gorilla CSRF middleware.
 

--- a/data/vcorp_065.md
+++ b/data/vcorp_065.md
@@ -85,8 +85,6 @@ This is a severe NoSQL injection vulnerability in Acme Corp's Golang backend ser
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A critical NoSQL injection vulnerability has been identified in Acme Corp's backend services built with Golang and MongoDB. The vulnerability exists in the `FindUser` API endpoint which accepts user input via the `search` query parameter and directly converts it into a MongoDB query without proper validation or sanitization.
 

--- a/data/vcorp_066.md
+++ b/data/vcorp_066.md
@@ -65,8 +65,6 @@ This vulnerability involves a path traversal flaw in Acme Corp's internal Go web
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A path traversal vulnerability has been identified in Acme Corp's internal Go web application, specifically in the file retrieval endpoint `/read`. The vulnerability exists because the application directly concatenates user-supplied input from the URL query parameter `file` to a base directory path without proper validation or sanitization.
 

--- a/data/vcorp_067.md
+++ b/data/vcorp_067.md
@@ -87,8 +87,6 @@ This vulnerability involves direct concatenation of untrusted HTTP parameters in
    - Integrity (I): None (N) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L
-
 # Description
 A critical SQL injection vulnerability exists in Acme Corp's user management API written in Go. The vulnerability is present in the `/search` endpoint's handler function, where untrusted user input from the `username` query parameter is directly concatenated into a SQL query using string formatting (`fmt.Sprintf`) without proper sanitization or parameterization.
 

--- a/data/vcorp_068.md
+++ b/data/vcorp_068.md
@@ -77,8 +77,6 @@ This vulnerability involves an XSS flaw in Acme Corp's Go-based web application 
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's Go-based web application. The vulnerability stems from improper handling of user input in the template rendering process, where the application directly concatenates unsanitized query parameters into HTML template strings before parsing.
 

--- a/data/vcorp_069.md
+++ b/data/vcorp_069.md
@@ -46,8 +46,6 @@ This vulnerability involves the absence of Subresource Integrity (SRI) verificat
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N
-
 # Description
 Acme Corp's customer portal is vulnerable to script tampering due to missing Subresource Integrity (SRI) attributes on externally hosted JavaScript libraries. Specifically, the jQuery library loaded from Google's CDN lacks the necessary cryptographic hash verification that would prevent the execution of modified scripts.
 

--- a/data/vcorp_070.md
+++ b/data/vcorp_070.md
@@ -52,8 +52,6 @@ This vulnerability involves an Android activity that is improperly exported, all
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
-
 # Description
 A critical security vulnerability has been identified in Acme Corp's Android mobile application where the `ControlPanelActivity` is incorrectly configured with `android:exported="true"` in the AndroidManifest.xml file without implementing proper permission checks. This misconfiguration exposes privileged administrative functionality to any application installed on the same device.
 

--- a/data/vcorp_071.md
+++ b/data/vcorp_071.md
@@ -60,8 +60,6 @@ This critical vulnerability stems from improper implementation of JWT token vali
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical authentication vulnerability has been identified in Acme Corp's Java authentication module built on Spring Boot and the Auth0 java-jwt library. The vulnerability stems from the application decoding JWT tokens without performing signature verification, which is a mandatory security step.
 

--- a/data/vcorp_072.md
+++ b/data/vcorp_072.md
@@ -58,8 +58,6 @@ This vulnerability involves a critical authentication bypass in Acme Corp's Java
    - Integrity (I): High (H) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:L
-
 # Description
 A critical authentication vulnerability exists in Acme Corp's Java-based authentication service that allows complete bypass of JWT verification. The vulnerability stems from the explicit use of the "none" algorithm (`Algorithm.none()`) in the JWT verification process, which effectively disables signature validation.
 

--- a/data/vcorp_073.md
+++ b/data/vcorp_073.md
@@ -63,8 +63,6 @@ This vulnerability allows attackers with high-level access to execute arbitrary 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A command injection vulnerability exists in Acme Corp's Java-based application running on Spring Boot with Apache Tomcat server. The vulnerability is located in the FileLogger module, which passes user-controlled input directly to system commands without proper validation or sanitization.
 

--- a/data/vcorp_074.md
+++ b/data/vcorp_074.md
@@ -50,8 +50,6 @@ This vulnerability involves the absence of the HttpOnly flag in session cookies 
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N
-
 # Description
 A security vulnerability was identified in Acme Corp's Java-based web application where session cookies are created without the `HttpOnly` flag. This misconfiguration allows client-side JavaScript to access sensitive session tokens through the `document.cookie` API, creating a significant security risk when combined with Cross-Site Scripting (XSS) vulnerabilities.
 

--- a/data/vcorp_075.md
+++ b/data/vcorp_075.md
@@ -47,8 +47,6 @@ This vulnerability involves a Java web application setting the JSESSIONID authen
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A security vulnerability has been identified in Acme Corp's Java-based web application running on Apache Tomcat, where the authentication session cookie (JSESSIONID) is being set without the 'secure' flag. This configuration error allows the session cookie to be transmitted over unencrypted HTTP connections, not just HTTPS.
 

--- a/data/vcorp_076.md
+++ b/data/vcorp_076.md
@@ -55,8 +55,6 @@ This vulnerability involves the improper use of the AES cipher in Electronic Cod
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 A significant cryptographic vulnerability has been identified in Acme Corp's enterprise Java application deployed on Apache Tomcat. The cryptographic module improperly employs the AES cipher in Electronic Code Book (ECB) mode (`AES/ECB/PKCS5Padding`) to encrypt sensitive data.
 

--- a/data/vcorp_077.md
+++ b/data/vcorp_077.md
@@ -68,8 +68,6 @@ This vulnerability involves the use of Java's `NullCipher` in Acme Corp's authen
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A critical cryptographic vulnerability exists in Acme Corp's Java-based authentication microservice where the application implements `javax.crypto.Cipher.getInstance("NullCipher")` instead of a secure encryption algorithm. The `NullCipher` is a non-encrypting cipher implementation that simply passes data through unchanged, providing zero cryptographic protection despite being used to process sensitive information including identity card data.
 

--- a/data/vcorp_078.md
+++ b/data/vcorp_078.md
@@ -82,8 +82,6 @@ This vulnerability involves a fundamentally flawed SSL implementation in Acme Co
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A serious security vulnerability was discovered in Acme Corp's Java-based backend services, where SSL certificate validation has been completely disabled through the implementation of an empty `X509TrustManager`. The vulnerable code creates a custom trust manager that accepts all certificates without any validation, effectively nullifying the security provided by SSL/TLS.
 

--- a/data/vcorp_079.md
+++ b/data/vcorp_079.md
@@ -75,8 +75,6 @@ This vulnerability involves the use of unencrypted Java sockets (`java.net.Socke
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A serious cryptographic vulnerability has been identified in Acme Corp's Java-based microservices deployed on Apache Tomcat (Java 11), where sensitive network communications are implemented using unencrypted `java.net.Socket` connections instead of secure alternatives.
 

--- a/data/vcorp_080.md
+++ b/data/vcorp_080.md
@@ -68,8 +68,6 @@ This vulnerability involves the use of the cryptographically broken MD5 hash alg
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:H/A:N
-
 # Description
 Acme Corp's Java application contains a critical security vulnerability in its authentication system, where the MD5 hash algorithm is used for generating cryptographic signatures for authentication tokens. MD5 is cryptographically broken and lacks collision resistance, which means attackers can potentially generate different inputs that produce identical hash values.
 

--- a/data/vcorp_081.md
+++ b/data/vcorp_081.md
@@ -64,8 +64,6 @@ This vulnerability involves the use of non-cryptographic random number generator
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A significant security vulnerability has been identified in Acme Corp's Java-based authentication module where session tokens are generated using `java.util.Random()` instead of cryptographically secure alternatives. This implementation is found in the Spring Boot application deployed in a Tomcat environment.
 

--- a/data/vcorp_082.md
+++ b/data/vcorp_082.md
@@ -60,8 +60,6 @@ This vulnerability involves the generation of RSA keys with insufficient bit len
    - Integrity (I): High (H) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
-
 # Description
 A security vulnerability exists in Acme Corp's payment processing microservice where Java components are generating RSA key pairs with a length of 1024 bits, well below the NIST-recommended minimum of 2048 bits. This issue was identified during a security audit through static code review of the payment processing module deployed on Apache Tomcat using Java (JDK 11).
 

--- a/data/vcorp_083.md
+++ b/data/vcorp_083.md
@@ -50,8 +50,6 @@ This vulnerability involves direct user input interpolation into SQL queries usi
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-
 # Description
 A SQL injection vulnerability has been identified in Acme Corp's Java web application built on Spring Boot with a MySQL backend. The vulnerability exists in the user authentication module where user-supplied input is directly interpolated into SQL queries using Java's `String.format()` method without any validation or sanitization.
 

--- a/data/vcorp_084.md
+++ b/data/vcorp_084.md
@@ -72,8 +72,6 @@ This vulnerability involves an LDAP injection issue in Acme Corp's Java-based HR
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
-
 # Description
 An LDAP injection vulnerability has been identified in Acme Corp's Java-based HR management system that uses Spring Boot. The vulnerability is located in the user search module, specifically in the `LdapUserSearch.searchUser()` method. The code directly concatenates unsanitized user input from HTTP request parameters into an LDAP query filter without proper validation or encoding.
 

--- a/data/vcorp_085.md
+++ b/data/vcorp_085.md
@@ -67,8 +67,6 @@ This vulnerability involves unsafe Java object deserialization in an enterprise 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical insecure deserialization vulnerability has been identified in Acme Corp's Java-based enterprise application running on Apache Tomcat with Spring Boot. The affected component is a servlet that processes incoming HTTP POST requests by directly deserializing Java objects from the request input stream without any validation or integrity checking.
 

--- a/data/vcorp_086.md
+++ b/data/vcorp_086.md
@@ -54,8 +54,6 @@ This vulnerability involves an unvalidated redirection flaw in Acme Corp's Java-
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 An unvalidated redirect vulnerability exists in Acme Corp's Java-based web application, specifically in a Spring Boot controller endpoint that handles redirection to user-supplied destination URLs. When a request is made to the `/redirect` endpoint with a `destination` parameter, the application performs a redirect to the specified URL without any validation or filtering.
 

--- a/data/vcorp_087.md
+++ b/data/vcorp_087.md
@@ -58,8 +58,6 @@ This vulnerability represents a classic Reflected Cross-Site Scripting (XSS) iss
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A Reflected Cross-Site Scripting (XSS) vulnerability exists in Acme Corp's legacy Java web application, specifically in the `GreetingServlet` class that processes the `/greet` endpoint. The vulnerable code directly concatenates unsanitized user input from the `name` request parameter into an HTML response without any encoding or escaping:
 

--- a/data/vcorp_088.md
+++ b/data/vcorp_088.md
@@ -63,8 +63,6 @@ This vulnerability involves an improperly configured XML parser in Acme Corp's J
    - Integrity (I): None (N) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L
-
 # Description
 An XML External Entity (XXE) vulnerability has been identified in Acme Corp's Java-based processing service. The vulnerability exists in the XML parsing functionality where the `DocumentBuilderFactory` is configured with default settings that enable DOCTYPE declarations, allowing for XXE attacks.
 

--- a/data/vcorp_089.md
+++ b/data/vcorp_089.md
@@ -63,8 +63,6 @@ This vulnerability involves the insecure configuration of Jackson's default typi
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical insecure deserialization vulnerability exists in Acme Corp's Java-based microservices, specifically in a Spring Boot application using Jackson 2.9.x for JSON processing. The application enables Jackson's default typing globally without proper validation constraints, allowing polymorphic type handling for untrusted input. This configuration permits deserialization of arbitrary Java classes specified in JSON payloads.
 

--- a/data/vcorp_090.md
+++ b/data/vcorp_090.md
@@ -60,8 +60,6 @@ This vulnerability involves an insecurely configured XML parser in Acme Corp's e
    - Integrity (I): Low (L) 
    - Availability (A): Low (L) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
-
 # Description
 An XML External Entity (XXE) vulnerability has been discovered in Acme Corp's enterprise Java application. The vulnerability exists in the XML parsing component that uses Java's built-in DocumentBuilderFactory without proper security configurations. Specifically, the application fails to disable the processing of external Document Type Definitions (DTDs) and external entities, making it susceptible to XXE attacks when processing user-controlled XML input.
 

--- a/data/vcorp_091.md
+++ b/data/vcorp_091.md
@@ -91,8 +91,6 @@ This vulnerability involves unsanitized user input being directly incorporated i
    - Integrity (I): None (N) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N
-
 # Description
 An LDAP injection vulnerability has been identified in Acme Corp's Java-based web application running on Apache Tomcat with Active Directory integration. The vulnerability exists in the `UserSearchServlet` class where the application directly incorporates an unsanitized HTTP request parameter (`uid`) into an LDAP search filter without proper validation or escaping.
 

--- a/data/vcorp_092.md
+++ b/data/vcorp_092.md
@@ -63,8 +63,6 @@ This vulnerability analysis examines a critical SpEL injection vulnerability in 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical SpEL (Spring Expression Language) injection vulnerability has been identified in Acme Corp's Spring Boot application. The vulnerability exists in a REST controller endpoint that directly evaluates user-supplied input as SpEL expressions without any validation or sanitization.
 

--- a/data/vcorp_093.md
+++ b/data/vcorp_093.md
@@ -55,8 +55,6 @@ This vulnerability involves an unvalidated redirect in Acme Corp's Java Spring a
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
-
 # Description
 An open redirect vulnerability has been identified in Acme Corp's Java Spring application within the `RedirectController`. This controller accepts a user-supplied `target` parameter and uses it directly to create a URL for redirection without any validation or sanitization.
 

--- a/data/vcorp_094.md
+++ b/data/vcorp_094.md
@@ -56,8 +56,6 @@ This vulnerability involves an Angular controller directly assigning user-provid
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
-
 # Description
 An open redirect vulnerability exists in Acme Corp's AngularJS web application. The vulnerability is located in the RedirectController, which handles URL redirections. The controller takes a user-supplied parameter (`redirectUrl`) from the route parameters and directly assigns it to `$window.location.href` without performing any validation or sanitization.
 

--- a/data/vcorp_095.md
+++ b/data/vcorp_095.md
@@ -49,8 +49,6 @@ This vulnerability exists in Acme Corp's legacy AngularJS (v1.6.8) application d
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N
-
 # Description
 A significant cross-site scripting (XSS) vulnerability has been identified in Acme Corp's legacy AngularJS (v1.6.8) application due to the deliberate disabling of Angular's built-in Strict Contextual Escaping (SCE) protection mechanism in the application's core configuration. SCE is a crucial security feature in AngularJS that automatically sanitizes potentially dangerous content before rendering it in the browser, thus preventing XSS attacks.
 

--- a/data/vcorp_096.md
+++ b/data/vcorp_096.md
@@ -69,8 +69,6 @@ This vulnerability involves command injection in an AWS Lambda function where us
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-
 # Description
 A critical command injection vulnerability has been identified in an AWS Lambda function that uses the Node.js `child_process.exec()` method to execute shell commands with unsanitized user input. The vulnerability allows attackers to inject arbitrary commands by manipulating the `event.directory` parameter, which is directly concatenated into a shell command string without validation.
 

--- a/data/vcorp_097.md
+++ b/data/vcorp_097.md
@@ -55,8 +55,6 @@ This vulnerability allows remote attackers to execute arbitrary JavaScript code 
    - Integrity (I): High (H) 
    - Availability (A): High (H) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-
 # Description
 A critical vulnerability has been discovered in an Acme Corp AWS Lambda function that processes user input from API Gateway events. The function directly passes unvalidated, user-supplied input to JavaScript's `eval()` function, enabling arbitrary code execution within the Lambda environment.
 

--- a/data/vcorp_098.md
+++ b/data/vcorp_098.md
@@ -56,8 +56,6 @@ This vulnerability involves a client-side DOM-based XSS in Acme Corp's single-pa
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A DOM-based Cross-Site Scripting (XSS) vulnerability has been discovered in Acme Corp's single-page JavaScript application. The application extracts the "default" query parameter from the URL and directly injects it into the page's DOM without proper sanitization or validation.
 

--- a/data/vcorp_099.md
+++ b/data/vcorp_099.md
@@ -51,8 +51,6 @@ This vulnerability represents a severe client-side code injection flaw in Acme C
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A DOM-based Cross-Site Scripting (XSS) vulnerability has been identified in Acme Corp's Single Page Application built with React and vanilla JavaScript. The vulnerability exists in the dynamic content handler that processes URL query parameters.
 

--- a/data/vcorp_100.md
+++ b/data/vcorp_100.md
@@ -53,8 +53,6 @@ This vulnerability involves a client-side DOM-based Cross-Site Scripting (XSS) f
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
-
 # Description
 A DOM-based Cross-Site Scripting (XSS) vulnerability has been discovered in Acme Corp's legacy user management portal, specifically in the profile update component. The vulnerability stems from improper handling of user-controlled input obtained from URL query parameters.
 

--- a/data/vcorp_101.md
+++ b/data/vcorp_101.md
@@ -56,8 +56,6 @@ This vulnerability involves the direct assignment of user-controlled input to wi
    - Integrity (I): Low (L) 
    - Availability (A): None (N) 
 
-CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
-
 # Description
 A client-side open redirect and XSS vulnerability exists in Acme Corp's web application within a React.js component. The vulnerable code directly assigns a user-controlled parameter (`$PROP`) to `window.location` without proper validation or sanitization:
 


### PR DESCRIPTION
This pull request removes CVSS vector strings from the vulnerability descriptions in multiple files within the `data` directory. These changes simplify the documentation by removing redundant information, as the CVSS details are likely captured elsewhere.